### PR TITLE
Add React TypeScript scaffold with worker client

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useWorld } from './hooks/useWorld';
+import MapCanvas from './MapCanvas';
+import HookList from './HookList';
+
+/** Main application component. */
+const App: React.FC = () => {
+  const { world, completeHook } = useWorld();
+
+  return (
+    <div className="App">
+      <MapCanvas mesh={world.mesh} states={world.states} />
+      <HookList hooks={world.hooks} completeHook={completeHook} />
+    </div>
+  );
+};
+
+export default App;

--- a/src/HookList.tsx
+++ b/src/HookList.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { AdventureHook } from './hooks/useWorld';
+
+interface Props {
+  hooks: AdventureHook[];
+  completeHook(id: string, success: boolean): void;
+}
+
+/**
+ * Simple list of adventure hooks with completion buttons.
+ */
+const HookList: React.FC<Props> = ({ hooks, completeHook }) => {
+  return (
+    <ul>
+      {hooks.map((hook) => (
+        <li key={hook.id}>
+          {hook.description}
+          {hook.completed ? (
+            <span> - completed</span>
+          ) : (
+            <button onClick={() => completeHook(hook.id, true)}>Complete</button>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default HookList;

--- a/src/MapCanvas.tsx
+++ b/src/MapCanvas.tsx
@@ -1,0 +1,99 @@
+import React, { useRef, useEffect, useState } from 'react';
+import type { Mesh, State } from '../worker';
+
+interface Props {
+  mesh?: Mesh;
+  states?: State[];
+}
+
+/**
+ * Canvas component for rendering the map mesh and state boundaries.
+ */
+const MapCanvas: React.FC<Props> = ({ mesh, states }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [transform, setTransform] = useState({ x: 0, y: 0, scale: 1 });
+  const dragging = useRef(false);
+  const lastPos = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !mesh) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const { width, height } = canvas;
+    ctx.save();
+    ctx.clearRect(0, 0, width, height);
+    ctx.translate(transform.x, transform.y);
+    ctx.scale(transform.scale, transform.scale);
+
+    // Draw triangles
+    for (let i = 0; i < mesh.triangles.length; i += 3) {
+      const a = mesh.triangles[i] * 2;
+      const b = mesh.triangles[i + 1] * 2;
+      const c = mesh.triangles[i + 2] * 2;
+      ctx.beginPath();
+      ctx.moveTo(mesh.points[a], mesh.points[a + 1]);
+      ctx.lineTo(mesh.points[b], mesh.points[b + 1]);
+      ctx.lineTo(mesh.points[c], mesh.points[c + 1]);
+      ctx.closePath();
+      ctx.strokeStyle = '#999';
+      ctx.stroke();
+    }
+
+    // TODO: draw states properly
+    if (states) {
+      ctx.strokeStyle = '#ff0000';
+      states.forEach((state) => {
+        const cells = state.cellIndices;
+        ctx.beginPath();
+        cells.forEach((id, idx) => {
+          const idx2 = id * 2;
+          if (idx === 0) ctx.moveTo(mesh.points[idx2], mesh.points[idx2 + 1]);
+          else ctx.lineTo(mesh.points[idx2], mesh.points[idx2 + 1]);
+        });
+        ctx.closePath();
+        ctx.stroke();
+      });
+    }
+    ctx.restore();
+  }, [mesh, states, transform]);
+
+  const onWheel = (e: React.WheelEvent) => {
+    e.preventDefault();
+    const delta = e.deltaY < 0 ? 1.1 : 0.9;
+    setTransform((t) => ({ ...t, scale: t.scale * delta }));
+  };
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    dragging.current = true;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+  };
+
+  const onMouseMove = (e: React.MouseEvent) => {
+    if (!dragging.current) return;
+    const dx = e.clientX - lastPos.current.x;
+    const dy = e.clientY - lastPos.current.y;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+    setTransform((t) => ({ ...t, x: t.x + dx, y: t.y + dy }));
+  };
+
+  const onMouseUp = () => {
+    dragging.current = false;
+  };
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={800}
+      height={600}
+      onWheel={onWheel}
+      onMouseDown={onMouseDown}
+      onMouseMove={onMouseMove}
+      onMouseUp={onMouseUp}
+      // TODO: style via CSS
+    />
+  );
+};
+
+export default MapCanvas;

--- a/src/hooks/useWorld.ts
+++ b/src/hooks/useWorld.ts
@@ -1,0 +1,119 @@
+import { useEffect, useState, useCallback } from 'react';
+import type {
+  Mesh,
+  MapData,
+  State,
+  Road,
+  Cell,
+  Burg,
+  StateOptions,
+  RoadOptions,
+  ElevationParams,
+  Constraints,
+  RiverParams,
+} from '../../worker';
+import {
+  generateMesh,
+  assignElevation,
+  assignRivers,
+  loadMapJSON,
+  generateStates,
+  generateRoads,
+} from '../workerClient';
+
+/** Adventure hook description. */
+export interface AdventureHook {
+  id: string;
+  description: string;
+  completed?: boolean;
+}
+
+/** Shape of the world state stored by the application. */
+export interface WorldState {
+  mesh?: Mesh;
+  peaks?: number[];
+  elevationT?: Float32Array;
+  elevationR?: Float32Array;
+  flowT?: Float32Array;
+  mapData?: MapData;
+  states?: State[];
+  roads?: Road[];
+  hooks: AdventureHook[];
+}
+
+const STORAGE_KEY = 'world-state';
+
+/**
+ * Custom hook managing world generation and persistence.
+ */
+export function useWorld() {
+  const [world, setWorld] = useState<WorldState>(() => {
+    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+    if (raw) {
+      try {
+        const parsed: WorldState = JSON.parse(raw);
+        return { ...parsed, hooks: parsed.hooks || [] };
+      } catch {
+        // TODO: better error handling
+      }
+    }
+    return { hooks: [] };
+  });
+
+  // Persist world whenever it changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...world, hooks: world.hooks }));
+    } catch {
+      // TODO: better error handling
+    }
+  }, [world]);
+
+  const initWorld = useCallback(async () => {
+    try {
+      const { mesh, peaks } = await generateMesh();
+      setWorld((w) => ({ ...w, mesh, peaks }));
+
+      const elevationParams: ElevationParams = {
+        noisyCoastlines: 0.5,
+        hillHeight: 0.3,
+        mountainSharpness: 0.8,
+        oceanDepth: 1.0,
+      };
+      const constraints: Constraints = { size: 1024, constraints: new Float32Array() };
+      const elev = await assignElevation({ mesh, peaks }, elevationParams, constraints);
+      setWorld((w) => ({ ...w, elevationT: elev.elevationT, elevationR: elev.elevationR }));
+
+      const riverParams: RiverParams = { flow: 1, minFlow: 0.1, riverWidth: 1 };
+      const rivers = await assignRivers({ mesh }, riverParams);
+      setWorld((w) => ({ ...w, flowT: rivers.flowT }));
+
+      const mapData = await loadMapJSON('/maps/example.map');
+      setWorld((w) => ({ ...w, mapData }));
+
+      const states = await generateStates(mapData.cells as Cell[], { count: 5 } as StateOptions);
+      setWorld((w) => ({ ...w, states }));
+
+      const roads = await generateRoads(mapData.burgs as Burg[], { maxDistance: 50 } as RoadOptions);
+      setWorld((w) => ({ ...w, roads }));
+    } catch (err) {
+      console.error(err);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!world.mesh) {
+      initWorld();
+    }
+  }, [world.mesh, initWorld]);
+
+  const completeHook = useCallback((id: string, success: boolean) => {
+    // TODO: send to LoreEngine worker when integrated
+    setWorld((w) => ({
+      ...w,
+      hooks: w.hooks.map((h) => (h.id === id ? { ...h, completed: success } : h)),
+    }));
+  }, []);
+
+  return { world, completeHook };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+// TODO: global styles
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/src/workerClient.ts
+++ b/src/workerClient.ts
@@ -1,0 +1,78 @@
+import type { Mesh, Cell, State, Burg, Road, MapData, StateOptions, RoadOptions, ElevationParams, Constraints, RiverParams } from '../worker';
+
+/**
+ * Wrapper around the map generation WebWorker. Provides promise based
+ * accessors for each command defined in `worker.ts`.
+ */
+class WorkerClient {
+  private worker: Worker;
+  private pending: Record<string, Array<{resolve: (data: any) => void; reject: (err: Error) => void}>> = {};
+
+  constructor() {
+    this.worker = new Worker(new URL('../worker.ts', import.meta.url));
+    this.worker.onmessage = this.handleMessage.bind(this);
+  }
+
+  private handleMessage(event: MessageEvent) {
+    const { cmd, data, error } = event.data as { cmd: string; data?: any; error?: string };
+    const baseCmd = cmd.replace(/Error$/, '');
+    const queue = this.pending[baseCmd];
+    if (!queue || queue.length === 0) return;
+    const { resolve, reject } = queue.shift()!;
+    if (cmd.endsWith('Error')) {
+      reject(new Error(error));
+    } else {
+      resolve(data);
+    }
+  }
+
+  private call<T>(cmd: string, payload: any): Promise<T> {
+    return new Promise((resolve, reject) => {
+      if (!this.pending[cmd]) this.pending[cmd] = [];
+      this.pending[cmd].push({ resolve, reject });
+      this.worker.postMessage({ cmd, payload });
+    });
+  }
+
+  /** Generate the mesh and peak triangles. */
+  generateMesh(config?: { pointCount: number }): Promise<{ mesh: Mesh; peaks: number[] }> {
+    // Worker currently ignores config
+    return this.call<{ mesh: Mesh; peaks: number[] }>('generateMesh', config);
+  }
+
+  /** Assign elevation across the mesh. */
+  assignElevation(data: { mesh: Mesh; peaks: number[] }, params: ElevationParams, constraints: Constraints): Promise<{ elevationT: Float32Array; elevationR: Float32Array }> {
+    return this.call<{ elevationT: Float32Array; elevationR: Float32Array }>('assignElevation', { data, params, constraints });
+  }
+
+  /** Compute river flow. */
+  assignRivers(data: { mesh: Mesh }, params: RiverParams): Promise<{ flowT: Float32Array }> {
+    return this.call<{ flowT: Float32Array }>('assignRivers', { data, params });
+  }
+
+  /** Load an exported FMG map JSON file. */
+  loadMapJSON(path: string): Promise<MapData> {
+    return this.call<MapData>('loadMapJSON', path);
+  }
+
+  /** Generate states from cells. */
+  generateStates(cells: Cell[], options: StateOptions): Promise<State[]> {
+    return this.call<State[]>('generateStates', { cells, options });
+  }
+
+  /** Generate roads between burgs. */
+  generateRoads(burgs: Burg[], params: RoadOptions): Promise<Road[]> {
+    return this.call<Road[]>('generateRoads', { burgs, params });
+  }
+}
+
+const workerClient = new WorkerClient();
+
+export const generateMesh = workerClient.generateMesh.bind(workerClient);
+export const assignElevation = workerClient.assignElevation.bind(workerClient);
+export const assignRivers = workerClient.assignRivers.bind(workerClient);
+export const loadMapJSON = workerClient.loadMapJSON.bind(workerClient);
+export const generateStates = workerClient.generateStates.bind(workerClient);
+export const generateRoads = workerClient.generateRoads.bind(workerClient);
+
+export default workerClient;


### PR DESCRIPTION
## Summary
- set up React app entry and components
- wrap `worker.ts` in a promise‑based client
- add world state hook with localStorage persistence
- basic `MapCanvas` and `HookList` components

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c280149a0832c9312c5797e6932b6