### PR TITLE
Add API endpoint tests

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -1,0 +1,48 @@
+import request from 'supertest';
+import app from '../src/server';
+
+jest.mock('../src/api/lore', () => ({
+  generateLore: jest.fn().mockResolvedValue({
+    title: 'Title',
+    type: 'Type',
+    tags: ['tag'],
+    lore: 'Lore text'
+  })
+}));
+
+jest.mock('../src/api/hooks', () => ({
+  generateAdventureHooksFromLore: jest.fn().mockResolvedValue(['hook1', 'hook2'])
+}));
+
+describe('POST /api/lore', () => {
+  it('returns 400 when `topic` is missing', async () => {
+    const res = await request(app).post('/api/lore').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 and JSON with required keys when `topic` is provided', async () => {
+    const res = await request(app).post('/api/lore').send({ topic: 'castle' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        title: expect.any(String),
+        type: expect.any(String),
+        tags: expect.anything(),
+        lore: expect.any(String)
+      })
+    );
+  });
+});
+
+describe('POST /api/hooks', () => {
+  it('returns 400 when `lore` is missing', async () => {
+    const res = await request(app).post('/api/hooks').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 and JSON array when `lore` is provided', async () => {
+    const res = await request(app).post('/api/hooks').send({ lore: {} });
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest + SuperTest tests for `/api/lore` and `/api/hooks`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_686e3da83108832ca402b16f13d9a87d