### PR TITLE
Add ant farm simulator with procedural digging

### DIFF
--- a/__tests__/antFarm.test.ts
+++ b/__tests__/antFarm.test.ts
@@ -1,0 +1,12 @@
+import { createGrid, step, Ant } from '../src/antFarm';
+
+describe('ant farm simulation', () => {
+  it('allows an ant to dig downward through sand', () => {
+    const grid = createGrid(3, 3);
+    const ants: Ant[] = [{ x: 1, y: 0 }];
+    step(grid, ants);
+    expect(grid[1][1]).toBe(0);
+    expect(ants[0].y).toBe(1);
+  });
+});
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@pinecone-database/pinecone": "^6.1.1",
+        "dotenv": "^17.2.1",
         "express": "^4.18.2",
         "openai": "^5.8.3",
         "react": "^18.2.0",
@@ -16,6 +17,7 @@
       },
       "devDependencies": {
         "@testing-library/react": "^14.0.0",
+        "@types/express": "^5.0.3",
         "@types/jest": "^29.5.14",
         "@types/node": "^24.0.12",
         "@types/react": "^19.1.8",
@@ -1216,12 +1218,58 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
+      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
+      "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -1232,6 +1280,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1313,6 +1368,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.0.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.12.tgz",
@@ -1340,6 +1402,20 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
@@ -1358,6 +1434,29 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -2365,6 +2464,18 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@pinecone-database/pinecone": "^6.1.1",
+    "dotenv": "^17.2.1",
     "express": "^4.18.2",
     "openai": "^5.8.3",
     "react": "^18.2.0",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",
+    "@types/express": "^5.0.3",
     "@types/jest": "^29.5.14",
     "@types/node": "^24.0.12",
     "@types/react": "^19.1.8",

--- a/src/AntFarm.tsx
+++ b/src/AntFarm.tsx
@@ -1,0 +1,67 @@
+import React, { useRef, useEffect } from 'react';
+import { createGrid, step, Ant } from './antFarm';
+
+const WIDTH = 120;
+const HEIGHT = 80;
+const SCALE = 4; // size of each cell in pixels
+
+/** Canvas component that simulates ants digging tunnels through sand. */
+const AntFarm: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const gridRef = useRef(createGrid(WIDTH, HEIGHT));
+  const antsRef = useRef<Ant[]>([]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    function draw() {
+      const grid = gridRef.current;
+
+      // Draw sand
+      ctx.fillStyle = '#deb887';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      // Clear empty cells
+      ctx.fillStyle = '#ffffff';
+      for (let y = 0; y < HEIGHT; y++) {
+        for (let x = 0; x < WIDTH; x++) {
+          if (grid[y][x] === 0) {
+            ctx.clearRect(x * SCALE, y * SCALE, SCALE, SCALE);
+          }
+        }
+      }
+
+      // Draw ants
+      ctx.fillStyle = '#000000';
+      for (const ant of antsRef.current) {
+        ctx.fillRect(ant.x * SCALE, ant.y * SCALE, SCALE, SCALE);
+      }
+    }
+
+    function tick() {
+      if (antsRef.current.length < 50) {
+        antsRef.current.push({ x: Math.floor(Math.random() * WIDTH), y: 0 });
+      }
+      step(gridRef.current, antsRef.current);
+      draw();
+      requestAnimationFrame(tick);
+    }
+
+    tick();
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={WIDTH * SCALE}
+      height={HEIGHT * SCALE}
+      style={{ border: '1px solid #000' }}
+    />
+  );
+};
+
+export default AntFarm;
+

--- a/src/App.css
+++ b/src/App.css
@@ -1,15 +1,8 @@
 /* App.css */
 .App {
   display: flex;
+  justify-content: center;
+  align-items: center;
   height: 100vh;
   margin: 0;
-}
-.MapPane {
-  flex: 3;
-  border-right: 1px solid #ccc;
-}
-.HookPane {
-  flex: 1;
-  overflow-y: auto;
-  padding: 1rem;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,15 @@
 import React from 'react';
-import { useWorld } from './hooks/useWorld';
-import MapCanvas from './MapCanvas';
-import HookList from './HookList';
+import AntFarm from './AntFarm';
 import './App.css';
 
-/** Main application component. */
+/** Main application component rendering the ant farm simulator. */
 const App: React.FC = () => {
-  const { world, status, error, completeHook } = useWorld();
-
-  if (status === 'loading') {
-    return <div>Loading…</div>;
-  }
-  if (status === 'error') {
-    return <div className="Error">Error: {error}</div>;
-  }
-
   return (
     <div className="App">
-      <div className="MapPane">
-        <MapCanvas mesh={world.mesh} states={world.states} />
-      </div>
-      <div className="HookPane">
-        <HookList
-          hooks={world.hooks}
-          status={status}
-          completeHook={completeHook}
-        />
-      </div>
+      <AntFarm />
     </div>
   );
 };
 
 export default App;
+

--- a/src/antFarm.ts
+++ b/src/antFarm.ts
@@ -1,0 +1,57 @@
+export type Cell = 0 | 1;
+
+export interface Ant {
+  x: number;
+  y: number;
+}
+
+/** Create a grid filled with sand (1) except the top row which is empty. */
+export function createGrid(width: number, height: number): Cell[][] {
+  return Array.from({ length: height }, (_, y) =>
+    Array.from({ length: width }, () => (y === 0 ? 0 : 1))
+  );
+}
+
+
+/**
+ * Advance the simulation by one step, moving ants and carving tunnels.
+ */
+export function step(grid: Cell[][], ants: Ant[]): void {
+  const height = grid.length;
+  const width = grid[0].length;
+
+  for (let i = ants.length - 1; i >= 0; i--) {
+    const ant = ants[i];
+    const moves: Array<[number, number]> = [[0, 1], [-1, 1], [1, 1]];
+    if (Math.random() < 0.5) {
+      [moves[1], moves[2]] = [moves[2], moves[1]];
+    }
+
+    let moved = false;
+    for (const [dx, dy] of moves) {
+      const nx = ant.x + dx;
+      const ny = ant.y + dy;
+      if (nx < 0 || nx >= width || ny >= height) {
+        continue;
+      }
+      if (grid[ny][nx] === 1) {
+        grid[ny][nx] = 0; // dig through sand
+        ant.x = nx;
+        ant.y = ny;
+        moved = true;
+        break;
+      } else if (grid[ny][nx] === 0) {
+        ant.x = nx;
+        ant.y = ny;
+        moved = true;
+        break;
+      }
+    }
+
+    if (!moved || ant.y >= height - 1) {
+      // remove ants that cannot move or reached bottom
+      ants.splice(i, 1);
+    }
+  }
+}
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,12 +1,12 @@
 import 'dotenv/config';
-import express from 'express';
+import express, { Request, Response } from 'express';
 import { generateLore } from './api/lore';
 import { generateAdventureHooksFromLore } from './api/hooks';
 
 const app = express();
 app.use(express.json());
 
-app.post('/api/lore', async (req, res) => {
+app.post('/api/lore', async (req: Request, res: Response) => {
   const { topic } = req.body as { topic?: string };
   if (!topic) {
     res.status(400).json({ error: 'Missing topic' });
@@ -21,7 +21,7 @@ app.post('/api/lore', async (req, res) => {
   }
 });
 
-app.post('/api/hooks', async (req, res) => {
+app.post('/api/hooks', async (req: Request, res: Response) => {
   const { lore } = req.body as { lore?: any };
   if (!lore) {
     res.status(400).json({ error: 'Missing lore' });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
-  "extends": "./node_modules/react-scripts/tsconfig.json",
   "compilerOptions": {
-    "jsx": "react-jsx"
+    "target": "ES2019",
+    "module": "commonjs",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
   },
-  "include": [
-    "src",
-    "__tests__"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src", "__tests__"],
+  "exclude": ["node_modules"]
 }
+


### PR DESCRIPTION
## Summary
- create ant farm simulation logic with grid-based sand and moving ants
- render ant farm on canvas and show ants digging tunnels
- center canvas in app and adjust server/typescript config for tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fbb768744832c806597f4d35bcafd